### PR TITLE
Disabling WP_DEBUG by default as it throws many errors.

### DIFF
--- a/wp-config-vagrant.php
+++ b/wp-config-vagrant.php
@@ -55,7 +55,7 @@ $table_prefix = 'wp_';
  * It is strongly recommended that plugin and theme developers use WP_DEBUG
  * in their development environments.
  */
-define( 'WP_DEBUG', true );
+define( 'WP_DEBUG', false );
 
 /**#@+
  * Authentication Unique Keys and Salts.


### PR DESCRIPTION
This can be later enabled by updating `wp-config-vagrant.php` file in the repo.